### PR TITLE
Expand portfolio with detailed resume sections

### DIFF
--- a/awards.html
+++ b/awards.html
@@ -17,9 +17,11 @@ layout: none
   <main id="awards">
     <h2>Honors &amp; Awards</h2>
     <ul>
-      <li>Winner, Karnataka State Police Datathon 2024</li>
-      <li>Runner-up, Ideathon Invente ’23; Trump the Aces ’23</li>
-      <li>Multiple circuit-design wins (REC, SSN-CE, CEG, Coulomb) 2022–2023</li>
+      <li>Winner — Karnataka State Police Datathon 2024 (KSP, Microsoft India)</li>
+      <li>Runner-up — Trump the Aces (Circuit Design); 2nd Runner-up — Innovete Challenge (Ideathon), Invente ’23, SSN-CE</li>
+      <li>Runner-up — CTRL-Z, Kurukshetra ’23, CEG (Anna University)</li>
+      <li>Winner — Solder-It; Runner-up — E-Maze, Invente ’22, SSN-CE</li>
+      <li>Winner — Circuit Debugging; 2nd Runner — DIY Electronics, Coulomb ’22, Rajalakshmi Engineering College</li>
     </ul>
   </main>
 

--- a/contact.html
+++ b/contact.html
@@ -16,12 +16,12 @@ layout: none
 
   <main id="contact">
     <h2>Contact</h2>
-    <p>Feel free to reach out via:</p>
+    <p>Let’s build useful AI with real-world impact. Reach out via:</p>
     <ul>
       <li>Email: <a href="mailto:sandeep.sath7@gmail.com">sandeep.sath7@gmail.com</a></li>
       <li>Phone: +91-7550112670</li>
-      <li>GitHub: <a href="https://github.com/sandepstele" target="_blank">github.com/sandepstele</a></li>
-      <li>LinkedIn: <a href="https://www.linkedin.com/in/sandeepstele/" target="_blank">linkedin.com/in/sandeepstele</a></li>
+      <li>GitHub: <a href="https://github.com/sandeepstele" target="_blank">github.com/sandeepstele</a></li>
+      <li>LinkedIn: <a href="https://linkedin.com/in/sandeepstele" target="_blank">linkedin.com/in/sandeepstele</a></li>
     </ul>
   </main>
 

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@ layout: none
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Sandeep S • Home</title>
+  <meta name="description" content="ML engineer building LLM agents, RAG search, geospatial analytics, and medical AI. TA at IIT-M; published at IEEE CSNT 2025."/>
+  <meta name="keywords" content="LLM agent, RAG, FAISS, FastAPI, TensorFlow, XGBoost, geospatial analytics, medical imaging, IIT Madras, Paradox fest, datathon winner"/>
   <link rel="stylesheet" href="css/style.css"/>
 </head>
 <body>
@@ -15,30 +17,42 @@ layout: none
   {% include header.html %}
 
   <main>
+    <!-- Hero -->
+    <section id="hero">
+      <h2>Hero</h2>
+      <p>I build practical ML and data systems. I like turning messy data into useful tools.</p>
+      <p><strong>Now:</strong> Teaching Assistant for Business Data Management at IIT Madras. I also build LLM tools and healthcare ML projects.</p>
+    </section>
+
+    <!-- About -->
+    <section id="about">
+      <h2>About</h2>
+      <p>I work across <strong>machine learning</strong>, <strong>data engineering</strong>, and <strong>product</strong>. My projects include <strong>LLM agents</strong>, <strong>vector search</strong>, <strong>geospatial analysis</strong>, and <strong>medical imaging</strong>. I led <strong>Paradox’25</strong> at IIT Madras (~5,000 attendees) and published work on <strong>multimodal osteoarthritis detection</strong> (IEEE CSNT 2025).</p>
+      <p>I focus on simple, reliable services: containerised apps, clean pipelines, and safe sandboxes. I value clear interfaces and good documentation as much as model accuracy.</p>
+    </section>
+
+    <!-- Quick Facts -->
+    <section id="quick-facts">
+      <h2>Quick Facts</h2>
+      <ul>
+        <li><strong>Education:</strong> B.E. ECE (Easwari, 2021–2025, CGPA 8.77); B.S. Data Science &amp; Applications (IIT Madras, 2022–2026, CGPA 8.45)</li>
+        <li><strong>Core skills:</strong> Python, FastAPI, Docker/Podman, RAG (FAISS/Pinecone), OpenAI/LLM orchestration, Scikit-Learn, TensorFlow, XGBoost, SQLite, PostgreSQL, Flask, Django</li>
+        <li><strong>Interests:</strong> LLM agents, vector databases, MLOps, geospatial analytics, medical AI, event operations</li>
+      </ul>
+    </section>
+
     <!-- Education -->
     <section id="education">
       <h2>Education</h2>
       <div class="card">
-        <h3>Easwari Engineering College, Chennai</h3>
-        <p>
-          <strong>B.E. Electronics &amp; Communication</strong> (2021–2025)<br/>
-          CGPA: 8.77
-        </p>
-        <p>
-          Courses: Analog &amp; Digital Circuits, Control Systems, DSP,
-          VLSI Design, Medical Electronics
-        </p>
+        <h3>Easwari Engineering College — Chennai, India</h3>
+        <p><strong>B.E. in Electronics and Communication Engineering (2021–2025)</strong> • CGPA: 8.77</p>
+        <p><strong>Selected coursework:</strong> Analog &amp; Digital Circuits; Control Systems; Digital Signal Processing; VLSI Design; Medical Electronics</p>
       </div>
       <div class="card">
-        <h3>IIT Madras, Chennai</h3>
-        <p>
-          <strong>B.Sc. Data Science &amp; Applications</strong> (2022–2026)<br/>
-          CGPA: 8.45
-        </p>
-        <p>
-          Courses: Machine Learning, App Development, Business Analytics,
-          DSA, DBMS, Linux
-        </p>
+        <h3>Indian Institute of Technology Madras — Chennai, India</h3>
+        <p><strong>B.S. in Data Science &amp; Applications (2022–2026)</strong> • CGPA: 8.45</p>
+        <p><strong>Selected coursework:</strong> Machine Learning; Application Development; Business Analytics; Data Structures &amp; Algorithms; DBMS; Linux</p>
       </div>
     </section>
 
@@ -46,26 +60,35 @@ layout: none
     <section id="experience">
       <h2>Experience</h2>
       <div class="card">
-        <h3>Teaching Assistant, Business Data Management (MS2001)</h3>
-        <p><em>IIT Madras</em> • Jan 2024–Present</p>
+        <h3>Teaching Assistant — Business Data Management (MS2001), IIT Madras</h3>
+        <p>Jan 2024 – Present • Chennai</p>
         <ul>
-          <li>Conduct TA sessions; automate dataset generation &amp; validation in Python.</li>
-          <li>Built backend scripts to verify and grade student submissions.</li>
+          <li>Ran TA sessions and created datasets. Built Python scripts to auto-check submissions.</li>
+          <li>Worked on assessment workflows and content QA.</li>
+          <li>Topics: SQL design, indexing, transactions, and query performance.</li>
         </ul>
       </div>
       <div class="card">
-        <h3>Secretary, Paradox Student Fest</h3>
-        <p><em>IIT Madras</em> • Jan 2023–Present</p>
+        <h3>Secretary — Paradox, IIT Madras</h3>
+        <p>Jul 2024 – Jun 2025 • Chennai</p>
         <ul>
-          <li>Headed a ₹20 M budget fest (4 k+ attendees, 17 depts, 35+ events).</li>
-          <li>Deputy Head of Finance &amp; Ops: managed ₹13 M budget, optimized procurement.</li>
+          <li>Led Paradox’25: ~5,000 attendees, 17 departments, 35+ events, 5 pro shows.</li>
+          <li>Owned budgeting (~₹20M), procurement, venue roll-out, security, and show-day control.</li>
         </ul>
       </div>
       <div class="card">
-        <h3>Project Intern</h3>
-        <p><em>HCL Technologies, Chennai</em> • Jun 2023–Jul 2023</p>
+        <h3>Deputy Head — Finance &amp; Operations</h3>
+        <p>Jan 2024 – Jul 2024 • Chennai</p>
         <ul>
-          <li>Developed an ML-based course recommendation system.</li>
+          <li>Managed ₹13M across 15 departments and 30+ events.</li>
+          <li>Standardised expense tracking and final reporting.</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>Project Intern — HCL Technologies</h3>
+        <p>Jun 2023 – Jul 2023 • Chennai</p>
+        <ul>
+          <li>Built a Course Recommendation System using classical ML and analytics.</li>
         </ul>
       </div>
     </section>
@@ -74,22 +97,117 @@ layout: none
     <section id="research">
       <h2>Research</h2>
       <div class="card">
-        <h3>Early OA Detection</h3>
-        <p>
-          Multimodal approach combining X-rays &amp; clinical data for early
-          Osteoarthritis grading.<br/>
-          <em>IEEE CSNT ’25</em>
-        </p>
+        <h3>Modelling Clinical and Radiographic Data for Early Detection and Prediction of Osteoarthritis</h3>
+        <p>A multimodal pipeline that fuses X-ray features with clinical data for early OA detection and grading. Combines CNNs with XGBoost and includes an LLM layer for context-specific insights. <em>IEEE CSNT 2025</em>.</p>
       </div>
+    </section>
+
+    <!-- Featured Projects -->
+    <section id="featured-projects">
+      <h2>Featured Projects</h2>
+      <div class="card">
+        <h3>LLM-Based CI/CD Automation Agent</h3>
+        <p>An automation agent that reads plain English and performs tasks via a sandboxed API.</p>
+        <p><strong>Stack:</strong> Python, FastAPI, GPT-4o-Mini, Docker/Podman, SQLite, REST</p>
+      </div>
+      <div class="card">
+        <h3>Crime Analysis &amp; Prediction — Karnataka Police Datathon (Winner)</h3>
+        <p>Portal and dashboard for police FIR data with geospatial and behaviour analysis, plus time-series forecasts.</p>
+        <p><strong>Stack:</strong> Python, Django, Pandas, Scikit-Learn, Prophet, Tableau, Folium, Google Geocoding</p>
+      </div>
+      <div class="card">
+        <h3>Multimodal OA Detection with LLM-Generated Insights</h3>
+        <p>Flask app that fuses X-ray features with clinical data to predict OA and severity. RAG layer drafts personalised reports and powers a simple clinical chatbot.</p>
+        <p><strong>Stack:</strong> TensorFlow, XGBoost, Python, Flask, HTML/CSS/JS, FAISS, OpenAI API</p>
+      </div>
+      <div class="card">
+        <h3>TDS Virtual TA — Async RAG QA Service</h3>
+        <p>Async FastAPI service that ingests notes and forums, makes embeddings, and serves RAG answers.</p>
+        <p><strong>Flow:</strong> /query → embedding → top‑K retrieval → prompt → GPT‑4o‑mini → answer + sources.</p>
+      </div>
+      <div class="card">
+        <h3>Data Extraction &amp; Analysis Assistant</h3>
+        <p>FastAPI backend where you upload files and optional questions.txt. Generates code to extract answers in a controlled runner.</p>
+        <p><strong>Key files:</strong> main.py, llm.py, task_engine.py, frontend.html, start.sh, scripts/</p>
+      </div>
+    </section>
+
+    <!-- Earlier Projects -->
+    <section id="earlier-projects">
+      <h2>Earlier Projects</h2>
+      <ul>
+        <li><strong>Course Recommendation System (HCLTech, 2023):</strong> Suggests courses from skills and experience using classical ML.</li>
+        <li><strong>ML-Enhanced Non-Invasive Glucometer (2022):</strong> Improved NIR-based glucose estimates (~82% accuracy).</li>
+      </ul>
     </section>
 
     <!-- Honors & Awards -->
     <section id="awards">
-      <h2>Honors &amp; Awards</h2>
+      <h2>Honours &amp; Awards</h2>
       <ul>
-        <li>Winner, Karnataka State Police Datathon 2024</li>
-        <li>Runner-up, Ideathon Invente ’23; Trump the Aces ’23</li>
-        <li>Multiple circuit-design wins (REC, SSN-CE, CEG, Coulomb) 2022–2023</li>
+        <li>Winner — Karnataka State Police Datathon 2024 (KSP, Microsoft India)</li>
+        <li>Runner-up — Trump the Aces (Circuit Design); 2nd Runner-up — Innovete Challenge (Ideathon), Invente ’23, SSN-CE</li>
+        <li>Runner-up — CTRL-Z, Kurukshetra ’23, CEG (Anna University)</li>
+        <li>Winner — Solder-It; Runner-up — E-Maze, Invente ’22, SSN-CE</li>
+        <li>Winner — Circuit Debugging; 2nd Runner — DIY Electronics, Coulomb ’22, Rajalakshmi Engineering College</li>
+      </ul>
+    </section>
+
+    <!-- Leadership & Operations -->
+    <section id="leadership">
+      <h2>Leadership &amp; Operations</h2>
+      <ul>
+        <li>Ran end-to-end operations for Paradox’25: runbooks, vendor SLAs, and show-day control room.</li>
+        <li>Managed ₹13M–₹20M budgets with line-item tracking and audits.</li>
+        <li>Built inventory systems and checklists to reduce waste and delays.</li>
+      </ul>
+    </section>
+
+    <!-- Skills -->
+    <section id="skills">
+      <h2>Skills</h2>
+      <ul>
+        <li><strong>Languages:</strong> Python, SQL (SQLite/PostgreSQL), Bash</li>
+        <li><strong>Frameworks:</strong> FastAPI, Flask, Django</li>
+        <li><strong>ML / AI:</strong> Scikit-Learn, TensorFlow/Keras, XGBoost, RAG (FAISS/Pinecone), prompt engineering, evaluation</li>
+        <li><strong>Data:</strong> Pandas, NumPy, ETL, data validation, schema design</li>
+        <li><strong>Systems:</strong> Docker/Podman, REST APIs, async I/O, CI</li>
+        <li><strong>Visualisation:</strong> Matplotlib, Tableau, Folium</li>
+        <li><strong>ECE / Hardware basics:</strong> Analog &amp; digital circuits; control systems; DSP; VLSI fundamentals; medical electronics</li>
+        <li><strong>Domains:</strong> Geospatial analytics, medical AI, event ops, business data management</li>
+      </ul>
+    </section>
+
+    <!-- Teaching & Mentorship -->
+    <section id="teaching">
+      <h2>Teaching &amp; Mentorship</h2>
+      <p>Led practical sessions for Business Data Management on data modelling, query tuning, and data integrity.</p>
+    </section>
+
+    <!-- Patents & Publications -->
+    <section id="patents-publications">
+      <h2>Patents &amp; Publications</h2>
+      <ul>
+        <li><strong>Patent:</strong> Prediction and Grading of Knee Osteoarthritis using a Late Fusion Model with Integrated LLM-Enhanced Insights — Application No. 202541071393 A (India), 2025.</li>
+        <li><strong>Publication:</strong> Modelling Clinical and Radiographic Data for Early Detection and Prediction of Osteoarthritis — IEEE CSNT 2025.</li>
+      </ul>
+    </section>
+
+    <!-- Notes for Recruiters / Collaborators -->
+    <section id="notes">
+      <h2>Notes for Recruiters / Collaborators</h2>
+      <p>I like roles where I own the whole problem: scope, data, models, deployment, and feedback loops. Strengths: calm under pressure, clean interfaces, reproducible pipelines, and clear docs.</p>
+    </section>
+
+    <!-- Contact -->
+    <section id="contact">
+      <h2>Contact</h2>
+      <p>Let’s build useful AI with real-world impact.</p>
+      <ul>
+        <li>Email: <a href="mailto:sandeep.sath7@gmail.com">sandeep.sath7@gmail.com</a></li>
+        <li>Phone: +91 75501 12670</li>
+        <li>GitHub: <a href="https://github.com/sandeepstele" target="_blank">github.com/sandeepstele</a></li>
+        <li>LinkedIn: <a href="https://linkedin.com/in/sandeepstele" target="_blank">linkedin.com/in/sandeepstele</a></li>
       </ul>
     </section>
   </main>

--- a/work.html
+++ b/work.html
@@ -5,25 +5,45 @@ title: Work
 ---
 
 <section id="projects">
-  <h2>Projects</h2>
+  <h2>Featured Projects</h2>
 
   <div class="card">
-    <h3>LLM-Based Automation Agent</h3>
-    <p>Secure GPT-4o-Mini agent parsing &amp; executing English tasks via REST; containerized with Docker/Podman.</p>
-    <p><strong>Tech:</strong> Python · FastAPI · GPT-4o-Mini · Docker · REST API · SQLite</p>
+    <h3>LLM-Based CI/CD Automation Agent</h3>
+    <p>An automation agent that reads plain English and performs tasks via a sandboxed API.</p>
+    <p><strong>Stack:</strong> Python · FastAPI · GPT-4o-Mini · Docker/Podman · SQLite · REST</p>
   </div>
 
   <div class="card">
-    <h3>Crime Analysis &amp; Prediction</h3>
-    <p>Dynamic dashboard for Karnataka Police hackathon: geospatial &amp; time-series forecasting.</p>
-    <p><strong>Tech:</strong> Python · Django · Google Geocoding · Prophet · Tableau · Folium</p>
+    <h3>Crime Analysis &amp; Prediction — Karnataka Police Datathon (Winner)</h3>
+    <p>Portal and dashboard for police FIR data with geospatial and behaviour analysis, plus time-series forecasts.</p>
+    <p><strong>Stack:</strong> Python · Django · Pandas · Scikit-Learn · Prophet · Tableau · Folium · Google Geocoding</p>
   </div>
 
   <div class="card">
-    <h3>Multimodal OA Detection App</h3>
-    <p>Flask app fusing TensorFlow &amp; XGBoost + RAG pipeline for auto-reports &amp; chatbot.</p>
-    <p><strong>Tech:</strong> Flask · TensorFlow · FAISS · OpenAI API · HTML/CSS/JS</p>
+    <h3>Multimodal OA Detection with LLM-Generated Insights</h3>
+    <p>Flask app that fuses X-ray features with clinical data to predict OA and severity. RAG layer drafts personalised reports and powers a simple clinical chatbot.</p>
+    <p><strong>Stack:</strong> TensorFlow · XGBoost · Python · Flask · HTML/CSS/JS · FAISS · OpenAI API</p>
   </div>
+
+  <div class="card">
+    <h3>TDS Virtual TA — Async RAG QA Service</h3>
+    <p>Async FastAPI service that ingests notes and forums, makes embeddings, and serves RAG answers.</p>
+    <p><strong>Flow:</strong> /query → embedding → top‑K retrieval → prompt → GPT‑4o‑mini → answer + sources</p>
+  </div>
+
+  <div class="card">
+    <h3>Data Extraction &amp; Analysis Assistant</h3>
+    <p>FastAPI backend with a small HTML page where uploads are processed through LLM-generated Python code in a controlled runner.</p>
+    <p><strong>Key files:</strong> main.py · llm.py · task_engine.py · frontend.html · start.sh · scripts/</p>
+  </div>
+</section>
+
+<section id="earlier-projects">
+  <h2>Earlier Projects</h2>
+  <ul>
+    <li><strong>Course Recommendation System (HCLTech, 2023):</strong> Suggests courses from skills and experience using classical ML.</li>
+    <li><strong>ML-Enhanced Non-Invasive Glucometer (2022):</strong> Improved NIR-based glucose estimates (~82% accuracy).</li>
+  </ul>
 </section>
 
 <section id="publications">
@@ -31,9 +51,7 @@ title: Work
 
   <ul>
     <li>
-      Trishulam S., Sandeep S. et al., “Multimodal Osteoarthritis Detection,”
-      <em>IEEE CSNT ’25</em>.
+      "Modelling Clinical and Radiographic Data for Early Detection and Prediction of Osteoarthritis" — <em>IEEE CSNT 2025</em>.
     </li>
-    <!-- add more publication entries here -->
   </ul>
 </section>


### PR DESCRIPTION
## Summary
- overhaul home page with hero intro, extended resume sections, and SEO meta tags
- expand project listings and earlier work on dedicated work page
- update awards and contact pages with detailed information

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d388a6d48832881acd24e3d565c13