### PR TITLE
Add resume page, LinkedIn contact info, and patent entry

### DIFF
--- a/_includes/_includes/header.html
+++ b/_includes/_includes/header.html
@@ -2,11 +2,13 @@
   <h1 class="name">Sandeep S</h1>
   <p class="contact">
     <a href="mailto:sandeep.sath7@gmail.com">sandeep.sath7@gmail.com</a> |
-    <a href="https://github.com/sandeepstele" target="_blank">github.com/sandeepstele</a>
+    <a href="https://github.com/sandeepstele" target="_blank">github.com/sandeepstele</a> |
+    <a href="https://www.linkedin.com/in/sandeepstele/" target="_blank">linkedin.com/in/sandeepstele</a>
   </p>
   <nav class="main-nav">
     <a href="{{ site.baseurl }}/index.html">Home</a>
     <a href="{{ site.baseurl }}/about.html">About</a>
+    <a href="{{ site.baseurl }}/resume.html">Resume</a>
     <a href="{{ site.baseurl }}/projects.html">Projects</a>
     <a href="{{ site.baseurl }}/publications.html">Publications</a>
     <a href="{{ site.baseurl }}/awards.html">Awards</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,11 +2,13 @@
   <h1 class="name">Sandeep S</h1>
   <p class="contact">
     <a href="mailto:sandeep.sath7@gmail.com">sandeep.sath7@gmail.com</a> |
-    <a href="https://github.com/sandeepstele" target="_blank">github.com/sandeepstele</a>
+    <a href="https://github.com/sandeepstele" target="_blank">github.com/sandeepstele</a> |
+    <a href="https://www.linkedin.com/in/sandeepstele/" target="_blank">linkedin.com/in/sandeepstele</a>
   </p>
   <nav class="main-nav">
     <a href="index.html">Home</a>
     <a href="about.html">About</a>
+    <a href="resume.html">Resume</a>
     <a href="projects.html">Projects</a>
     <a href="publications.html">Publications</a>
     <a href="awards.html">Awards</a>

--- a/about.html
+++ b/about.html
@@ -17,15 +17,6 @@ title: About
     <li><strong>Interests:</strong> LLM agents, vector databases, MLOps, geospatial analytics, medical AI, event operations</li>
   </ul>
 </section>
-
-<section id="resume">
-  <h2>Resume</h2>
-  <object data="assets/resume.pdf" type="application/pdf" width="100%" height="600">
-    <p><a href="assets/resume.pdf">Download Resume</a></p>
-  </object>
-  <p><a href="assets/resume.pdf" download>Download Resume</a></p>
-</section>
-
 <section id="education">
   <h2>Education</h2>
   <div class="card">

--- a/contact.html
+++ b/contact.html
@@ -20,6 +20,7 @@ layout: none
     <ul>
       <li>Email: <a href="mailto:sandeep.sath7@gmail.com">sandeep.sath7@gmail.com</a></li>
       <li>GitHub: <a href="https://github.com/sandeepstele" target="_blank">github.com/sandeepstele</a></li>
+      <li>LinkedIn: <a href="https://www.linkedin.com/in/sandeepstele/" target="_blank">linkedin.com/in/sandeepstele</a></li>
     </ul>
   </main>
 

--- a/publications.html
+++ b/publications.html
@@ -20,5 +20,8 @@ title: Publications
 
 <section id="patents">
   <h2>Patents</h2>
-  <p>None yet.</p>
+  <ul>
+    <li>Prediction and Grading of Knee Osteoarthritis using a Late Fusion Model with Integrated LLM-Enhanced Insights — Application No. 202541071393 A (India), 2025.</li>
+  </ul>
 </section>
+

--- a/resume.html
+++ b/resume.html
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Resume
+---
+
+<section id="resume">
+  <h2>Resume</h2>
+  <object data="assets/resume.pdf" type="application/pdf" width="100%" height="600">
+    <p><a href="assets/resume.pdf">Download Resume</a></p>
+  </object>
+  <p><a href="assets/resume.pdf" download>Download Resume</a></p>
+</section>
+
+


### PR DESCRIPTION
## Summary
- Move resume from About page to a standalone page and add navigation link
- Add LinkedIn link alongside email and GitHub in header and contact page
- Record osteoarthritis patent application in the publications list

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d45fbeb888328951d1ffecccf99d3