### PR TITLE
Add README details and remove old projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Sandeep S Portfolio
+
+This repository hosts the source for **Sandeep S**'s personal website. It is a static site built for GitHub Pages using Jekyll layouts and includes pages for projects, publications, courses and more.
+
+## Structure
+
+- `index.html` – landing page with hero and about sections.
+- `projects.html` – curated list of featured work.
+- `about.html`, `awards.html`, `courses.html`, etc. – additional sections of the site.
+- `assets/` and `css/` – shared images, PDF files and stylesheets.
+
+## Local development
+
+The site can be built with [Jekyll](https://jekyllrb.com/).
+
+```bash
+# Install Jekyll first if it isn't available
+jekyll serve
+```
+
+This starts a local server at <http://localhost:4000> with live reloading.
+

--- a/projects.html
+++ b/projects.html
@@ -37,10 +37,3 @@ title: Projects
   </div>
 </section>
 
-<section id="earlier-projects">
-  <h2>Earlier Projects</h2>
-  <ul>
-    <li><strong>Course Recommendation System (HCLTech, 2023):</strong> Suggests courses from skills and experience using classical ML.</li>
-    <li><strong>ML-Enhanced Non-Invasive Glucometer (2022):</strong> Improved NIR-based glucose estimates (~82% accuracy).</li>
-  </ul>
-</section>


### PR DESCRIPTION
## Summary
- document site structure and development steps in README
- drop earlier projects section so only current work is showcased

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d463e89d88328940696d3bcdd0653