### PR TITLE
chore: remove leadership section from about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -75,15 +75,6 @@ title: About
   </div>
 </section>
 
-<section id="leadership">
-  <h2>Leadership &amp; Operations</h2>
-  <ul>
-    <li>Ran end-to-end operations for Paradox’25: runbooks, vendor SLAs, and show-day control room.</li>
-    <li>Managed ₹13M–₹20M budgets with line-item tracking and audits.</li>
-    <li>Built inventory systems and checklists to reduce waste and delays.</li>
-  </ul>
-</section>
-
 <section id="skills">
   <h2>Skills</h2>
   <ul>


### PR DESCRIPTION
## Summary
- remove leadership and operations section from about page

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d4691109083289867f7f789d3524e